### PR TITLE
Remove support for the currentLocation option

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<operator xmlns="http://wirecloud.conwet.fi.upm.es/ns/macdescription/1" vendor="CoNWeT" name="ngsientity2poi" version="3.2.0a1">
+<operator xmlns="http://wirecloud.conwet.fi.upm.es/ns/macdescription/1" vendor="CoNWeT" name="ngsientity2poi" version="3.2.0">
   <details>
     <title>NGSI Entity To PoI</title>
     <homepage>https://github.com/wirecloud-fiware/ngsi-entity2poi-operator</homepage>

--- a/src/doc/changelog.md
+++ b/src/doc/changelog.md
@@ -1,6 +1,8 @@
-## 3.2.0 (2019-05-XX)
+## 3.2.0 (2019-05-13)
 
 - Use location as the default attribute for the coordinates attribute.
+- Remove support for the deprecated `currentLocation` option used on the map
+    widgets.
 
 
 ## 3.1.2 (2018-05-05)

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -106,15 +106,6 @@ var entity2poi, processData, processEntity;
             };
         }
 
-        // Provide a currentLocation attribute for backward compatibility
-        if (coordinates) {
-            poi.currentLocation = {
-                system: "WGS84",
-                lat: coordinates[0],
-                lng: coordinates[1]
-            };
-        }
-
         return poi;
     };
 

--- a/tests/js/NGSIEntity2PoISpec.js
+++ b/tests/js/NGSIEntity2PoISpec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Future Internet Consulting and Development Solutions S.L.
+ * Copyright (c) 2018-2019 Future Internet Consulting and Development Solutions S.L.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -146,6 +146,60 @@
             processEntity(entity);
 
             expect(entity2poi).toHaveBeenCalledWith(entity, [0, 1], entity.location);
+        });
+
+        it("support geojson coordinates (polygon)", () => {
+            spyOn(window, 'entity2poi');
+            MashupPlatform.prefs.set('coordinates_attr', 'location');
+
+            let geojson = {
+                type: "Polygon",
+                coordinates: [
+                    [
+                        [-3.80356167695194, 43.46296641666926],
+                        [-3.803161973253841, 43.46301091092682],
+                        [-3.803147082548618, 43.462879859445884],
+                        [-3.803536474744068, 43.462838666196674],
+                        [-3.80356167695194, 43.46296641666926]
+                    ]
+                ]
+            };
+            let entity = {location: geojson};
+            processEntity(entity);
+
+            expect(entity2poi).toHaveBeenCalledWith(entity, null, geojson);
+        });
+
+        describe("entity2poi(entity, coordinates, geojson)", () => {
+
+            it("Process entities without a geometry", () => {
+                let entity = {location: "0, 1"};
+                entity2poi(entity, [0, 1], null);
+            });
+
+            it("Process point geometries", () => {
+                let geojson = {type: "Point", coordinates: [1, 0]};
+                let entity = {location: geojson};
+                entity2poi(entity, [0, 1], geojson);
+            });
+
+            it("Process polygon geometries", () => {
+                let geojson = {
+                    type: "Polygon",
+                    coordinates: [
+                        [
+                            [-3.80356167695194, 43.46296641666926],
+                            [-3.803161973253841, 43.46301091092682],
+                            [-3.803147082548618, 43.462879859445884],
+                            [-3.803536474744068, 43.462838666196674],
+                            [-3.80356167695194, 43.46296641666926]
+                        ]
+                    ]
+                };
+                let entity = {location: geojson};
+                entity2poi(entity, null, geojson);
+            });
+
         });
 
     });


### PR DESCRIPTION
This PR removes support for the `currentLocation` option used on the PoI metadata used by map widgets. This option was released long ago, so it should not be a problem. Also this PR prepares release v3.2.0 of the widget.